### PR TITLE
Auto extend message acknowledge timeout in processor

### DIFF
--- a/javascript/CHANGELOG.md
+++ b/javascript/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.0.6
 
-* Add flag `jobDef.autoExtendAck` (set to true by default) to auto-extend message acknowledgement timeout
+* Add flag `jobDef.autoExtendAckTimeout` (set to true by default) to auto-extend message acknowledgement timeout
   to prevent message from being redelivered while `jobDef.perform` is processing the message.
 
 # 0.0.5

--- a/javascript/CHANGELOG.md
+++ b/javascript/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.0.6
+
+* Add flag `jobDef.autoExtendAck` (set to true by default) to auto-extend message acknowledgement timeout
+  to prevent message from being redelivered while `jobDef.perform` is processing the message.
+
 # 0.0.5
 
 * Gracefully handle shutdown when using `jobScheduler.scheduleRecurring`.

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nats-jobs",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nats-jobs",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats-jobs",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Background job processor using NATS and Redis",
   "author": "GovSpend",
   "main": "dist/index.js",
@@ -14,6 +14,7 @@
     "prepare": "npm run build",
     "build": "tsc --declaration",
     "test": "npm run lint",
+    "prettier": "prettier --ignore-path .gitignore --write './**/*.ts'",
     "lint": "eslint src/**"
   },
   "keywords": [

--- a/javascript/src/jobProcessor.ts
+++ b/javascript/src/jobProcessor.ts
@@ -2,6 +2,7 @@ import ms from 'ms'
 import {
   AckPolicy,
   connect,
+  ConsumerInfo,
   DeliverPolicy,
   DiscardPolicy,
   JsMsg,
@@ -10,7 +11,7 @@ import {
   RetentionPolicy,
   StorageType,
 } from 'nats'
-import { nanos, defer } from './util'
+import { nanos, defer, nanosToMs } from './util'
 import _debug from 'debug'
 import { Deferred, NatsOpts, JobDef } from './types'
 
@@ -41,7 +42,7 @@ const createStream = async (conn: NatsConnection, def: JobDef) => {
     discard: DiscardPolicy.Old,
     deny_delete: false,
     deny_purge: false,
-    ...def.streamConfig
+    ...def.streamConfig,
   }
   debug('STREAM CONFIG %O', config)
   // Add stream
@@ -57,7 +58,7 @@ const createConsumer = (conn: NatsConnection, def: JobDef) => {
     ack_wait: nanos('10s'),
     deliver_policy: DeliverPolicy.All,
     replay_policy: ReplayPolicy.Instant,
-    ...def.consumerConfig
+    ...def.consumerConfig,
   }
   debug('CONSUMER CONFIG %O', config)
   const js = conn.jetstream()
@@ -67,6 +68,25 @@ const createConsumer = (conn: NatsConnection, def: JobDef) => {
     mack: true,
     config,
   })
+}
+
+const extendAckThresholdFactor = 0.75
+const getExtendAckTimer = (
+  consumerInfo: ConsumerInfo,
+  msg: JsMsg
+): NodeJS.Timer => {
+  let extendInterval =
+    nanosToMs(consumerInfo.config.ack_wait) * extendAckThresholdFactor
+  // set up a timer to prevent a message from being redelivered
+  // while perform is processing it
+  return setInterval(() => {
+    debug('MSG EXTEND ACK %O', {
+      extendInterval,
+      msgInfo: msg.info,
+      consumerInfo,
+    })
+    msg.working()
+  }, extendInterval)
 }
 
 export const jobProcessor = async (opts?: NatsOpts) => {
@@ -82,15 +102,18 @@ export const jobProcessor = async (opts?: NatsOpts) => {
    * To gracefully shutdown see stop method.
    */
   const start = async (def: JobDef) => {
+    let extendAckTimer: NodeJS.Timer | undefined
     debug('JOB DEF %O', def)
     const pullInterval = def.pullInterval ?? ms('1s')
     const backoff = def.backoff ?? ms('1s')
     const batch = def.batch ?? 10
+    const autoExtendAck = def.autoExtendAck ?? true
     // Create stream
     // TODO: Maybe handle errors better
     await createStream(conn, def).catch()
     // Create pull consumer
     const ps = await createConsumer(conn, def)
+    const consumerInfo = await ps.consumerInfo()
     // Pull messages from the consumer
     const run = () => {
       ps.pull({ batch, expires: pullInterval })
@@ -103,6 +126,10 @@ export const jobProcessor = async (opts?: NatsOpts) => {
     for await (const msg of ps) {
       debug('RECEIVED', msg.info)
       deferred = defer()
+      if (autoExtendAck) {
+        extendAckTimer = getExtendAckTimer(consumerInfo, msg)
+      }
+
       try {
         await def.perform(msg, { signal: abortController.signal, def, js })
         debug('COMPLETED')
@@ -115,6 +142,9 @@ export const jobProcessor = async (opts?: NatsOpts) => {
         // Negative ack message with backoff
         msg.nak(backoffMs)
       } finally {
+        if (extendAckTimer) {
+          clearInterval(extendAckTimer)
+        }
         deferred.done()
       }
       // Don't process any more messages if stopping

--- a/javascript/src/types.ts
+++ b/javascript/src/types.ts
@@ -27,7 +27,7 @@ export interface JobDef {
   batch?: number
   backoff?: number | number[]
   numAttempts?: number
-  autoExtendAck?: boolean
+  autoExtendAckTimeout?: boolean
   perform(msg: JsMsg, opts: PerformOpts): Promise<void>
 }
 

--- a/javascript/src/types.ts
+++ b/javascript/src/types.ts
@@ -27,6 +27,7 @@ export interface JobDef {
   batch?: number
   backoff?: number | number[]
   numAttempts?: number
+  autoExtendAck?: boolean
   perform(msg: JsMsg, opts: PerformOpts): Promise<void>
 }
 

--- a/javascript/src/util.ts
+++ b/javascript/src/util.ts
@@ -1,7 +1,10 @@
 import ms from 'ms'
 import { Deferred } from './types'
+import { Nanos } from 'nats'
 
 export const nanos = (x: string) => ms(x) * 1e6
+
+export const nanosToMs = (x: Nanos | number | undefined) => (x ? x / 1e6 : 0)
 
 export const expBackoff = (
   startMs: number,


### PR DESCRIPTION
 - Add flag `jobDef.autoExtendAckTimeout` (set to true by default) to auto-extend message acknowledgement timeout
 to prevent message from being redelivered while `jobDef.perform` is processing the message.
 - Processor will signal NATS that message is still being worked on when threshold of 75% of consumer acknowledgement timeout is crossed