### PR TITLE
Improve aborting/awaiting of multiple jobs started with the same processor

### DIFF
--- a/javascript/CHANGELOG.md
+++ b/javascript/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.1
+
+* Add `await processor.finish()` if the caller wants to await all jobs currently being processed
+  to complete
+* Handle aborting/awaiting multiple job definitions started by the same processor
+
 # 0.1.0
 
 * Moved `jobScheduler` to [ha-job-scheduler](https://www.npmjs.com/package/ha-job-scheduler).

--- a/javascript/examples/abortSignal.ts
+++ b/javascript/examples/abortSignal.ts
@@ -5,7 +5,8 @@
  *
  * (1) Run script: npx ts-node examples/abortSignal.ts
  * (2) Publish a message: nats pub ORDERS someText
- * (3) Crl-C the script in the middle of the 1-5 log messages.
+ * (3) Optionally, also publish a message after a short period of time from step 2: nats pub ORDERS2 someOtherText
+ * (4) Crl-C the script in the middle of the 1-5 log messages.
  *
  * Requires NATS to be running.
  */
@@ -28,6 +29,12 @@ const def = {
     console.log(`Completed ${msg.info.streamSequence}`)
   },
 }
+
+const def2 = {
+  ...def,
+  stream: 'ORDERS2',
+}
+
 const run = async () => {
   const processor = await jobProcessor()
   // Gracefully handle signals
@@ -39,6 +46,7 @@ const run = async () => {
   process.on('SIGINT', shutDown)
   // Start processing messages
   processor.start(def)
+  processor.start(def2)
 }
 
 run()

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nats-jobs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nats-jobs",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats-jobs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Background job processor using NATS",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/javascript/src/jobProcessor.ts
+++ b/javascript/src/jobProcessor.ts
@@ -168,7 +168,8 @@ export const jobProcessor = async (opts?: ConnectionOptions) => {
     }
   }
   /**
-   * To be used from caller to await all jobs to be completed
+   * To be used from caller to await all jobs to be completed without
+   * signaling an abort and stopping the processing of messages
    */
   const finish = () => Promise.all(_.map('promise', deferreds))
   /**

--- a/javascript/src/types.ts
+++ b/javascript/src/types.ts
@@ -1,9 +1,4 @@
-import {
-  ConsumerConfig,
-  JsMsg,
-  StreamConfig,
-  JetStreamClient,
-} from 'nats'
+import { ConsumerConfig, JsMsg, StreamConfig, JetStreamClient } from 'nats'
 
 export interface PerformOpts {
   signal: AbortSignal


### PR DESCRIPTION
- Track each job definition start within the same processor
- Handle awaiting/aborting all jobs started by the same processor