### PR TITLE
Starting and stopping should be scoped to a single job def

### DIFF
--- a/javascript/CHANGELOG.md
+++ b/javascript/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 0.2.0
 
-* Starting and stopping are scoped to a single job definition. API change.
+* API changes!
+* Starting and stopping should be scoped to a single job def.
+* Top-level `stop` fn that stops all started jobs and closes the NATS connection.
+* Remove the exported Jetstream reference since we close the NATS connection and wouldn't know if that would break something down stream otherwise.
 
 # 0.1.0
 

--- a/javascript/CHANGELOG.md
+++ b/javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.0
+
+* Starting and stopping are scoped to a single job definition. API change.
+
 # 0.1.0
 
 * Moved `jobScheduler` to [ha-job-scheduler](https://www.npmjs.com/package/ha-job-scheduler).

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -53,7 +53,8 @@ process.on('SIGTERM', shutDown)
 process.on('SIGINT', shutDown)
 ```
 
-To gracefully shutdown mutliple jobs you could do something like this:
+To gracefully shutdown mutliple jobs and close the NATS connection call
+`stop` from the object returned by `jobProcessor`.
 
 ```typescript
 const processor = await jobProcessor()
@@ -63,6 +64,7 @@ const jobs = [
   processor.start(jobDef3),
 ]
 const shutDown = async () => {
+  // Shuts down jobs 1, 2, and 3 and closes the NATS connection
   await processor.stop()
   process.exit(0)
 }

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -7,9 +7,9 @@ See examples directory for more examples.
 
 ## Companion libraries
 
-* [ha-job-scheduler](https://www.npmjs.com/package/ha-job-scheduler)
-* [topology-runner](https://www.npmjs.com/package/topology-runner)
-* [nats-topology-runner](https://www.npmjs.com/package/nats-topology-runner)
+- [ha-job-scheduler](https://www.npmjs.com/package/ha-job-scheduler)
+- [topology-runner](https://www.npmjs.com/package/topology-runner)
+- [nats-topology-runner](https://www.npmjs.com/package/nats-topology-runner)
 
 ## Usage
 
@@ -41,20 +41,34 @@ const def = {
     console.log(`Completed ${msg.info.streamSequence}`)
   },
 }
-const run = async () => {
-  const processor = await jobProcessor()
-  // Gracefully handle shutdown
-  const shutDown = async () => {
-    await processor.stop()
-    process.exit(0)
-  }
-  process.on('SIGTERM', shutDown)
-  process.on('SIGINT', shutDown)
-  // Start processing messages
-  processor.start(def)
+
+const processor = await jobProcessor()
+const myJob = processor.start(jobDef)
+// Gracefully handle shutdown
+const shutDown = async () => {
+  await myJob.stop()
+  process.exit(0)
+}
+process.on('SIGTERM', shutDown)
+process.on('SIGINT', shutDown)
+```
+
+To gracefully shutdown mutliple jobs you could do something like this:
+
+```typescript
+const processor = await jobProcessor()
+const jobs = [
+  processor.start(jobDef1),
+  processor.start(jobDef2),
+  processor.start(jobDef3),
+]
+const shutDown = async () => {
+  await Promise.all(jobs.map((x) => x.stop()))
+  process.exit(0)
 }
 
-run()
+process.on('SIGTERM', shutDown)
+process.on('SIGINT', shutDown)
 ```
 
 Publish via NATS

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -63,7 +63,7 @@ const jobs = [
   processor.start(jobDef3),
 ]
 const shutDown = async () => {
-  await Promise.all(jobs.map((x) => x.stop()))
+  await processor.stop()
   process.exit(0)
 }
 

--- a/javascript/examples/abortSignal.ts
+++ b/javascript/examples/abortSignal.ts
@@ -30,15 +30,15 @@ const def = {
 }
 const run = async () => {
   const processor = await jobProcessor()
+  // Start processing messages
+  const ordersJob = processor.start(def)
   // Gracefully handle signals
   const shutDown = async () => {
-    await processor.stop()
+    await ordersJob.stop()
     process.exit(0)
   }
   process.on('SIGTERM', shutDown)
   process.on('SIGINT', shutDown)
-  // Start processing messages
-  processor.start(def)
 }
 
 run()

--- a/javascript/examples/successTest.ts
+++ b/javascript/examples/successTest.ts
@@ -28,15 +28,15 @@ const def = {
 }
 const run = async () => {
   const processor = await jobProcessor()
+  // Start processing messages
+  const ordersJob = processor.start(def)
   // Gracefully handle signals
   const shutDown = async () => {
-    await processor.stop()
+    await ordersJob.stop()
     process.exit(0)
   }
   process.on('SIGTERM', shutDown)
   process.on('SIGINT', shutDown)
-  // Start processing messages
-  processor.start(def)
 }
 
 run()

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nats-jobs",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nats-jobs",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats-jobs",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Background job processor using NATS",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/javascript/src/types.ts
+++ b/javascript/src/types.ts
@@ -28,3 +28,5 @@ export interface Deferred<A> {
   done: (value: A) => void
   promise: Promise<A>
 }
+
+export type StopFn = () => void

--- a/javascript/src/types.ts
+++ b/javascript/src/types.ts
@@ -29,4 +29,4 @@ export interface Deferred<A> {
   promise: Promise<A>
 }
 
-export type StopFn = () => void
+export type StopFn = () => Promise<void>


### PR DESCRIPTION
* Starting and stopping should be scoped to a single job def.
* Top-level `stop` fn that stops all started jobs and closes the NATS connection.
* Remove the exported Jetstream reference since we close the NATS connection and wouldn't know if that would break something down stream otherwise.