### PR TITLE
Perform timeout support

### DIFF
--- a/javascript/CHANGELOG.md
+++ b/javascript/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.8.0
+
+* Added `performTimeout` option to `JobDef` with a default of 3 hours.
+* If the timeout is reached before the processing of the message completes, an error is thrown so that
+* further processing can continue by the NATS consumer
+
 # 0.7.0
 
 * Added `durationMs` to `complete` and `error` events.

--- a/javascript/examples/processTimeout.ts
+++ b/javascript/examples/processTimeout.ts
@@ -1,37 +1,36 @@
 /*
- * Demonstrates how to stop an iterative job using the abort signal.
+ * Demonstrates perform timeout using the `performTimeout` option on JobDef.
  *
  * To Test:
  *
- * (1) Run script: npx ts-node examples/abortSignal.ts
+ * (1) Run script: npx ts-node examples/processTimeout.ts
  * (2) Publish a message: nats pub ORDERS someText
- * (3) Crl-C the script in the middle of the 1-5 log messages.
+ * (3) Wait one second to see the message be rejected with a timeout error.
  *
  * Requires NATS to be running.
  */
 import { JsMsg } from 'nats'
 import { setTimeout } from 'node:timers/promises'
 import { jobProcessor } from '../src/jobProcessor'
-import { Context } from '../src/types'
 
 const def = {
   stream: 'ORDERS',
-  async perform(msg: JsMsg, { signal }: Context) {
+  async perform(msg: JsMsg) {
     console.log(`Started ${msg.info.streamSequence}`)
-    for (let i = 0; i < 5; i++) {
-      await setTimeout(1000)
-      console.log(`Iteration ${i + 1} of 5`)
-      if (signal.aborted) {
-        return
-      }
-    }
+    await setTimeout(5000)
     console.log(`Completed ${msg.info.streamSequence}`)
   },
+  performTimeout: 1000,
+  numAttempts: 1,
 }
 const run = async () => {
   const processor = await jobProcessor()
   // Start processing messages
   const ordersJob = processor.start(def)
+  processor.emitter.on('start', console.info)
+  processor.emitter.on('complete', console.info)
+  processor.emitter.on('error', console.error)
+
   // Gracefully handle signals
   const shutDown = async () => {
     await ordersJob.stop()

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,20 +1,22 @@
 {
   "name": "nats-jobs",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nats-jobs",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "ISC",
       "dependencies": {
+        "bluebird": "^3.7.2",
         "debug": "^4.3.4",
         "eventemitter3": "^4.0.7",
         "lodash": "^4.17.21",
         "ms": "^2.1.3"
       },
       "devDependencies": {
+        "@types/bluebird": "^3.5.38",
         "@types/debug": "^4.1.7",
         "@types/jest": "^28.1.1",
         "@types/lodash": "^4.14.182",
@@ -1224,6 +1226,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/bluebird": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.38.tgz",
+      "integrity": "sha512-yR/Kxc0dd4FfwtEoLZMoqJbM/VE/W7hXn/MIjb+axcwag0iFmSPK7OBUZq1YWLynJUoWQkfUrI7T0HDqGApNSg==",
+      "dev": true
+    },
     "node_modules/@types/debug": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -1895,6 +1903,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -6336,6 +6349,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/bluebird": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.38.tgz",
+      "integrity": "sha512-yR/Kxc0dd4FfwtEoLZMoqJbM/VE/W7hXn/MIjb+axcwag0iFmSPK7OBUZq1YWLynJUoWQkfUrI7T0HDqGApNSg==",
+      "dev": true
+    },
     "@types/debug": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -6801,6 +6820,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats-jobs",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Background job processor using NATS",
   "author": "GovSpend",
   "main": "dist/index.js",
@@ -33,6 +33,7 @@
   },
   "license": "ISC",
   "dependencies": {
+    "bluebird": "^3.7.2",
     "debug": "^4.3.4",
     "eventemitter3": "^4.0.7",
     "lodash": "^4.17.21",
@@ -47,6 +48,7 @@
     "trailingComma": "es5"
   },
   "devDependencies": {
+    "@types/bluebird": "^3.5.38",
     "@types/debug": "^4.1.7",
     "@types/jest": "^28.1.1",
     "@types/lodash": "^4.14.182",

--- a/javascript/src/types.ts
+++ b/javascript/src/types.ts
@@ -1,9 +1,4 @@
-import {
-  ConsumerConfig,
-  JsMsg,
-  StreamConfig,
-  JetStreamClient,
-} from 'nats'
+import { ConsumerConfig, JsMsg, StreamConfig, JetStreamClient } from 'nats'
 
 export interface Context {
   signal: AbortSignal
@@ -22,6 +17,7 @@ export interface JobDef {
   numAttempts?: number
   autoExtendAckTimeout?: boolean
   perform(msg: JsMsg, context: Context): Promise<void>
+  performTimeout?: number
 }
 
 export interface Deferred<A> {
@@ -37,3 +33,14 @@ export interface BackoffOptions {
 }
 
 export type Events = 'start' | 'complete' | 'error'
+
+export class TimeoutError extends Error {
+  private timeout: number
+  private metadata: Record<string, unknown>
+  constructor(msg: string, timeout: number, metadata: Record<string, unknown>) {
+    super(msg)
+    this.timeout = timeout
+    this.metadata = metadata
+    Object.setPrototypeOf(this, TimeoutError.prototype)
+  }
+}


### PR DESCRIPTION
* Added `performTimeout` option to `JobDef` with a default of 3 hours.
* If the timeout is reached before the processing of the message completes, an error is thrown so that
* further processing can continue by the NATS consumer